### PR TITLE
Feature/cg1 28 refactor locations

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,11 +20,8 @@ export const App: React.FC = () => {
   const { isAuthenticated, logout, token } = useAuth();
   const [currentView, setCurrentView] = useState<"login" | "forgot">("login");
   const [selected, setSelected] = useState<string | null>(null);
-  const [locations, setLocations] = useState<{ id: string; name: string }[]>(
-    []
-  );
+  const [locations, setLocations] = useState<{ id: string; name: string }[]>([]);
   const [locationId, setLocationId] = useState<string>("");
-  const [courses, setCourses] = useState<string[]>([]);
   const [messagesData, setMessagesData] = useState<MenuMessage[]>([]);
   const [activeDm, setActiveDm] = useState<DMMessage | null>(null);
   const [thread, setThread] = useState<
@@ -42,8 +39,6 @@ export const App: React.FC = () => {
     getLocations(token)
       .then((data) => {
         setLocations(data);
-        setCourses(data.map((location: { name: any }) => location.name));
-        if (!selected && data.length) setSelected(data[0].name);
       })
       .catch((err) => console.error("Cannot fetch locations:", err));
   }, [token]);
@@ -51,11 +46,11 @@ export const App: React.FC = () => {
   // whenever the user picks a different course, update locationId
   useEffect(() => {
     if (!selected) return;
-    const match = locations.find((loc) => loc.name === selected);
+    const match = locations.find((location) => location.name === selected);
     setLocationId(match ? match.id : "");
   }, [selected, locations]);
 
-  // fetch message‐streams for the current location
+  // fetch messageStreams for the current location
   useEffect(() => {
     if (!token || !locationId) return;
     getMessageStreams(token, locationId)
@@ -68,8 +63,8 @@ export const App: React.FC = () => {
     logout();
     setCurrentView("login");
     setLocations([]);
+    setMessagesData([]);
   };
-
   // dev mode handleSelect function to retain sent messages for testing and development using localstorage
   const handleSelect = async (m: MenuMessage) => {
     const streamId = m.id;
@@ -118,7 +113,7 @@ export const App: React.FC = () => {
               </div>
               <Dropdown
                 buttonText={selected ?? "Select Location"}
-                items={courses}
+                items={locations}
                 onSelect={(item) => setSelected(item)}
               />
             </>
@@ -133,10 +128,6 @@ export const App: React.FC = () => {
                 // send to backend
                 await apiSend(token!, activeDm!.messageid, content);
 
-                // dev mode testing sent messages
-                // TODO: in production remove this block and re-fetch the full thread:
-                // const full = await getSingleMessageStream(token!, activeDm!.messageid);
-                // setThread(full.messages);
                 setThread((prev) => {
                   const newMsg = {
                     id: `local-${Date.now()}`,
@@ -157,8 +148,6 @@ export const App: React.FC = () => {
             />
           ) : (
             <Menu
-              locations={locations}
-              selected={selected}
               messagesArray={messagesData}
               onSelect={handleSelect}
             />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -63,7 +63,6 @@ export const App: React.FC = () => {
     logout();
     setCurrentView("login");
     setLocations([]);
-    setMessagesData([]);
   };
   // dev mode handleSelect function to retain sent messages for testing and development using localstorage
   const handleSelect = async (m: MenuMessage) => {

--- a/src/components/Dropdown.stories.tsx
+++ b/src/components/Dropdown.stories.tsx
@@ -1,27 +1,36 @@
 import { Dropdown } from "./Dropdown";
+interface Item {
+  id: string;
+  name: string;
+}
 
 interface DropdownArgs {
   buttonText: string;
-  items: string[];
+  items: Item[];
+  onSelect: (item: string) => void;
 }
 
 export default {
   title: "Components/Dropdown",
   component: Dropdown,
   args: {
-    buttonText: "Selected option",
-    items: ["Golf Course one", "Golf Course two", "Golf Course three"],
-    onSelect: (item: string) => console.log("Selected:", item),
+    buttonText: "Select Location",
+    items: [
+      { id: "1", name: "Golf Course one" },
+      { id: "2", name: "Golf Course two" },
+      { id: "3", name: "Golf Course three" },
+    ],
+    onSelect: (item: Item) => console.log("Selected:", item),
   },
 };
 
 const Template = (args: DropdownArgs) => {
-  const { buttonText, items } = args;
+  const { buttonText, items, onSelect } = args;
   return (
     <Dropdown
       buttonText={buttonText}
       items={items}
-      onSelect={(item: string) => console.log("Selected:", item)}
+      onSelect={onSelect}
     />
   );
 };

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -3,15 +3,20 @@ import {DropdownButton} from "./DropdownButton";
 import {DropdownContent} from "./DropdownContent";
 import { useState, useEffect, useRef } from "react";
 
+interface Item {
+  id: string;
+  name: string;
+}
+// items is an array of objects
 interface DropdownProps {
-    buttonText: string;
-    onSelect?: (item: string) => void;
-    items: string[];
-  }
+  buttonText: string;
+  onSelect?: (item: string) => void;
+  items: Item[];
+}
 
   export const Dropdown: React.FC<DropdownProps> = ({buttonText, onSelect, items}: DropdownProps) => {
     const [open, setOpen] = useState(false);
-    const [selectedItem, setSelectedItem] = useState<string>(buttonText || items[0]);
+    const [selectedItem, setSelectedItem] = useState<string>(buttonText || items[0].name);
 
     const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -42,16 +47,18 @@ interface DropdownProps {
     return (
         <div className="font-poppins font-regular relative flex flex-col gap-2" ref={dropdownRef}>
             <DropdownButton toggle={toggleDropdown} open={open}>{selectedItem} </DropdownButton>
-             <DropdownContent open={open}><ul> {items.map((item) => ( <li key={item}>
-        <button
-          className="w-full text-left px-4 py-2 hover:bg-gray-100"
-          onClick={() => handleSelect(item)}
-        >
-          {item}
-        </button>
-      </li>
-    ))}
-  </ul> </DropdownContent>
+            <DropdownContent open={open}>
+              <ul> {items.map((item) => ( <li key={item.id}>
+                <button
+                  className="w-full text-left px-4 py-2 hover:bg-gray-100"
+                  onClick={() => handleSelect(item.name)}
+                >
+                  {item.name}
+                </button>
+                </li>
+                ))}
+              </ul> 
+            </DropdownContent>
         </div>
     );
 };

--- a/src/components/Menu.stories.tsx
+++ b/src/components/Menu.stories.tsx
@@ -9,14 +9,13 @@ const mockLocations = [
   { id: "3", name: "Pebble Beach Golf Links" },
 ];
 
-const now = Date.now();
 const mockMessagesData: Message[] = [
   {
     id: "msg-1",
     clientName: "Bob Buddy Boy",
     clientImage: "https://example.com/image1.jpg",
     unreadCount: 0,
-    lastMessageAt: new Date(now - 68_000).toISOString(),
+    lastMessageAt: Date.now() - 6800000,
     lastMessage: "Short message",
     locationId: "1",
   },
@@ -25,7 +24,7 @@ const mockMessagesData: Message[] = [
     clientName: "Bobby Bot",
     clientImage: "https://example.com/image2.jpg",
     unreadCount: 70,
-    lastMessageAt: new Date(now - 95_000).toISOString(),
+    lastMessageAt: Date.now() - 2400000,
     lastMessage: "Short message",
     locationId: "1",
   },
@@ -34,7 +33,7 @@ const mockMessagesData: Message[] = [
     clientName: "Carson Carl Jr.",
     clientImage: "https://example.com/image3.jpg",
     unreadCount: 2,
-    lastMessageAt: new Date(now - 6_800_000).toISOString(),
+    lastMessageAt: Date.now() - 95000,
     lastMessage:
       "This is a long message, where the sentence is very redundant and long because it is long",
     locationId: "2",
@@ -44,7 +43,7 @@ const mockMessagesData: Message[] = [
     clientName: "Kaytlyn Lyn Lynda",
     clientImage: "https://example.com/image4.jpg",
     unreadCount: 50,
-    lastMessageAt: new Date(now - 2_400_000).toISOString(),
+    lastMessageAt: Date.now() - 2400000,
     lastMessage:
       "This is another long message, testing multiline display in the preview",
     locationId: "3",
@@ -77,8 +76,6 @@ type Story = StoryObj<typeof Menu>;
 
 export const Default: Story = {
   args: {
-    selected: null,
-    locations: mockLocations,
     messagesArray: [],
     onSelect: action("onSelect"),
   },
@@ -86,17 +83,13 @@ export const Default: Story = {
 
 export const PineValley: Story = {
   args: {
-    selected: mockLocations[0].name,
-    locations: mockLocations,
     messagesArray: getMessagesFor(mockLocations[0].name),
     onSelect: action("onSelect"),
   },
 };
 
-export const Augusta: Story = {
+export const AugustaNational: Story = {
   args: {
-    selected: mockLocations[1].name,
-    locations: mockLocations,
     messagesArray: getMessagesFor(mockLocations[1].name),
     onSelect: action("onSelect"),
   },
@@ -104,8 +97,6 @@ export const Augusta: Story = {
 
 export const PebbleBeach: Story = {
   args: {
-    selected: mockLocations[2].name,
-    locations: mockLocations,
     messagesArray: getMessagesFor(mockLocations[2].name),
     onSelect: action("onSelect"),
   },

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,6 +1,3 @@
-import React, { useState, useEffect } from "react";
-import { useAuth } from "../contexts/useAuth";
-import { getMessageStreams } from "./utils/api";
 import MessagePreview from "./MessagePreview";
 
 export interface Message {
@@ -19,51 +16,19 @@ export interface Location {
 }
 
 export interface MenuProps {
-  selected: string | null;
-  locations: Location[];
+  selected?: string;
   messagesArray?: Message[];
   onSelect: (message: Message) => void;
 }
 
-const Menu: React.FC<MenuProps> = ({
-  selected,
-  locations,
-  messagesArray,
-  onSelect,
-}) => {
-  const { token } = useAuth();
-  const [locationId, setLocationId] = useState<string>("0");
-  const [messagesData, setMessagesData] = useState<Message[]>(
-    messagesArray ?? []
-  );
-  const shouldFetch = messagesArray === undefined;
-
-  useEffect(() => {
-    if (messagesArray !== undefined) {
-      setMessagesData(messagesArray);
-    }
-  }, [messagesArray]);
-
-  useEffect(() => {
-    if (!shouldFetch || !selected) return;
-    const found = locations.find((location) => location.name === selected);
-    setLocationId(found ? found.id : "");
-  }, [selected, locations, shouldFetch]);
-
-  useEffect(() => {
-    if (!token || !shouldFetch || !locationId) return;
-    getMessageStreams(token, locationId)
-      .then((data) => setMessagesData(data))
-      .catch((err) => console.error("Cannot fetch message streams:", err));
-  }, [token, shouldFetch, locationId]);
-
+const Menu: React.FC<MenuProps> = ({ messagesArray, onSelect }) => {
   return (
     <div>
       <p className="font-poppins font-medium text-center text-base w-[152px] text-black border-b-2 border-b-black mt-[30px] mx-auto py-[10px]">
-        Messages ({messagesData.length})
+        Messages {messagesArray?.length ? `(${messagesArray.length})` : "(0)"}
       </p>
       <ul className="flex flex-col justify-center items-center mt-[16px] gap-[12px]">
-        {messagesData.map((message) => (
+       { messagesArray?.map((message) => (
           <li
             key={`${message.clientName}-${message.locationId}`}
             onClick={() => onSelect(message)}
@@ -78,7 +43,8 @@ const Menu: React.FC<MenuProps> = ({
               }}
             />
           </li>
-        ))}
+          ))
+        }
       </ul>
     </div>
   );

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -16,7 +16,6 @@ export interface Location {
 }
 
 export interface MenuProps {
-  selected?: string;
   messagesArray?: Message[];
   onSelect: (message: Message) => void;
 }


### PR DESCRIPTION
moves up the location props to the App file, for universal use

minimize useState calling by removing the courses variable, using only the locations variable

move up getMessageStreams to the App file for universal use 

logging into the app for the first time will display unselected location, and no messages

logging out, then logging back in will resume to the location where you left off.