### PR TITLE
[CG1-26] refactor(messaging): decode JWT for user identity & update send flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "communitee-golf-chat",
       "version": "1.0.0",
       "dependencies": {
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "storybook": "^8.6.12"
@@ -5161,6 +5162,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7020,6 +7030,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -7532,9 +7587,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.13.tgz",
-      "integrity": "sha512-Hgp8IF/yZDzKsN1hQWOuQZbrKiaFsbQud+07jJ8h9m9PaHWkpvZ5u55Xw5yYjWRXwRQ4jwFlJvY7T7FUJG9MCA==",
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8032,6 +8087,34 @@
         "@esbuild/win32-x64": "0.25.2"
       }
     },
+    "node_modules/vite-node/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vite-node/node_modules/rollup": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.0.tgz",
@@ -8073,15 +8156,18 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8755,6 +8841,34 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vitest/node_modules/rollup": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.0.tgz",
@@ -8806,15 +8920,18 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^8.6.12"

--- a/src/components/DMView.stories.tsx
+++ b/src/components/DMView.stories.tsx
@@ -14,6 +14,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     // DMView only needs id, username and picture for the header
+    currentUserId: "manager",
     message: {
       messageid: "1",
       username: "Manager",

--- a/src/components/DMView.tsx
+++ b/src/components/DMView.tsx
@@ -18,13 +18,20 @@ export interface Message {
 }
 
 interface DMViewProps {
+  currentUserId: string;
   thread: ThreadMsg[];
   message: Message;
   onBack: () => void;
   onSend: (content: string) => Promise<void>;
 }
 
-const DMView: React.FC<DMViewProps> = ({ message, onBack, onSend, thread }) => {
+const DMView: React.FC<DMViewProps> = ({
+  message,
+  onBack,
+  onSend,
+  thread,
+  currentUserId,
+}) => {
   const [draft, setDraft] = useState("");
 
   const handleSend = async () => {
@@ -61,7 +68,13 @@ const DMView: React.FC<DMViewProps> = ({ message, onBack, onSend, thread }) => {
       {/* Chat history */}
       <div className="flex-1 overflow-y-auto">
         {thread.map((msg) => {
-          const isOutbound = msg.senderId === "manager";
+          console.log(
+            "senderId:",
+            msg.senderId,
+            "currentUserId:",
+            currentUserId
+          );
+          const isOutbound = msg.senderId === currentUserId;
           const timestamp = new Date(msg.sentAt).getTime();
 
           return (

--- a/src/components/DMView.tsx
+++ b/src/components/DMView.tsx
@@ -68,12 +68,6 @@ const DMView: React.FC<DMViewProps> = ({
       {/* Chat history */}
       <div className="flex-1 overflow-y-auto">
         {thread.map((msg) => {
-          console.log(
-            "senderId:",
-            msg.senderId,
-            "currentUserId:",
-            currentUserId
-          );
           const isOutbound = msg.senderId === currentUserId;
           const timestamp = new Date(msg.sentAt).getTime();
 

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -2,15 +2,11 @@ import React, { useState } from "react";
 import { useAuth } from "../contexts/useAuth";
 
 export interface LoginFormProps {
-  onLogin: () => void;
   onClose?: () => void;
   onForgotPassword?: () => void;
 }
 
-export const LoginForm: React.FC<LoginFormProps> = ({
-  onLogin,
-  onForgotPassword,
-}) => {
+export const LoginForm: React.FC<LoginFormProps> = ({ onForgotPassword }) => {
   const [username, setUsername] = React.useState("");
   const [password, setPassword] = React.useState("");
 
@@ -34,7 +30,6 @@ export const LoginForm: React.FC<LoginFormProps> = ({
 
     try {
       await login(username, password);
-      onLogin();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message || "An unexpected error occurred");

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,60 +1,86 @@
-import React, {
-  useEffect,
-  useState,
-  ReactNode,
-} from "react";
+import React, { useEffect, useState, ReactNode } from "react";
 
 import { AUTH_TOKEN_KEY } from "../components/utils/constants";
 import { AuthContext } from "./AuthContextFoundation";
 import * as api from "../components/utils/api";
 
+interface JwtPayload {
+  userId: string;
+  username: string;
+}
+
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
+  const [user, setUser] = useState<{ id: string; name: string } | null>(null);
   const [token, setToken] = useState<string | null>(null);
+
+  const decodeJWT = (token: string): JwtPayload | null => {
+    try {
+      const [, b64url] = token.split(".");
+      const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+      const json = decodeURIComponent(
+        atob(b64)
+          .split("")
+          .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+          .join("")
+      );
+      return JSON.parse(json) as JwtPayload;
+    } catch {
+      return null;
+    }
+  };
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const chromeStorage = (window as any).chrome?.storage?.local;
-    if (chromeStorage?.get) {
+    const chromeAny = (window as any).chrome;
+    if (chromeAny?.storage?.local?.get) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      chromeStorage.get(AUTH_TOKEN_KEY, (items: Record<string, any>) => {
-        if (items[AUTH_TOKEN_KEY]) setToken(items[AUTH_TOKEN_KEY]);
+      chromeAny.storage.local.get(AUTH_TOKEN_KEY, (items: any) => {
+        const token = items[AUTH_TOKEN_KEY] as string | undefined;
+        if (!token) return;
+        setToken(token);
+        const payload = decodeJWT(token);
+        if (payload) setUser({ id: payload.userId, name: payload.username });
       });
     } else {
-      const stored = localStorage.getItem(AUTH_TOKEN_KEY);
-      if (stored) setToken(stored);
+      const token = localStorage.getItem(AUTH_TOKEN_KEY);
+      if (!token) return;
+      setToken(token);
+      const payload = decodeJWT(token);
+      if (payload) setUser({ id: payload.userId, name: payload.username });
     }
   }, []);
 
   const login = async (username: string, password: string) => {
     const newToken = await api.login(username, password);
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const chromeStorage = (window as any).chrome?.storage?.local;
-    if (chromeStorage?.set) {
-      chromeStorage.set({ [AUTH_TOKEN_KEY]: newToken });
+    const chromeAny = (window as any).chrome;
+    if (chromeAny?.storage?.local?.set) {
+      chromeAny.storage.local.set({ [AUTH_TOKEN_KEY]: newToken });
     } else {
       localStorage.setItem(AUTH_TOKEN_KEY, newToken);
     }
-
     setToken(newToken);
+    const payload = decodeJWT(newToken);
+    if (payload) setUser({ id: payload.userId, name: payload.username });
   };
 
   const logout = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const chromeStorage = (window as any).chrome?.storage?.local;
-    if (chromeStorage?.remove) {
-      chromeStorage.remove(AUTH_TOKEN_KEY);
+    const chromeAny = (window as any).chrome;
+    if (chromeAny?.storage?.local?.remove) {
+      chromeAny.storage.local.remove(AUTH_TOKEN_KEY);
     } else {
       localStorage.removeItem(AUTH_TOKEN_KEY);
     }
     setToken(null);
+    setUser(null);
   };
 
   return (
     <AuthContext.Provider
-      value={{ token, isAuthenticated: Boolean(token), login, logout }}
+      value={{ token, isAuthenticated: Boolean(token), login, logout, user }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/contexts/AuthContextFoundation.ts
+++ b/src/contexts/AuthContextFoundation.ts
@@ -3,6 +3,7 @@ import {createContext} from "react";
 export interface AuthContextType {
     token: string | null;
     isAuthenticated: boolean;
+    user: { id: string; name: string } | null;
     login: (username: string, password: string) => Promise<void>;
     logout: () => void;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
Summary: 
I refactored our auth flow to pull userId/username directly out of the JWT rather than relying on localStorage hacks or extra backend calls. The mock backend was already embedding that data in the token, so decoding it in the extension is the simplest way to know who’s “you” and mark sent bubbles correctly.

You will need to reinstall dependencies or just "npm install jwt-decode"

AuthContext:
	1.	Added a decodeJWT() helper to parse userId & username from the token payload
	2.	On init & login, stores token & decoded user in chrome.storage.local (with localStorage fallback)
	3.	Exposes user alongside token, login() & logout()

LoginForm:
	1.	Switched to using useAuth().login() for authentication
	2.	Centralized loading/error state

App.tsx:
	1.	Reads user.id from context and passes it to <DMView currentUserId={…} />
	2.	After sending, re-fetches the message‐stream list (so the preview updates) and then reloads the active thread

DMView:
	1.	Uses currentUserId to decide bubble color: orange for outbound, gray for inbound

This makes our chat UI correctly identify the sender on every message and keeps preview/threads in sync. All driven by the decoded JWT so it should work seamlessly in production with any JWT‐based backend.

JIRA TICKET: https://tripleten-apiary.atlassian.net/browse/CG1-26?atlOrigin=eyJpIjoiZjNhNjhkYTY2YTYzNDZkN2FkNTE3YWM1OGFkOWVmYmQiLCJwIjoiaiJ9